### PR TITLE
Gae 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ca.jimr</groupId>
 	<artifactId>gae-mini-profiler</artifactId>
-	<version>1.1.0</version>
+	<version>1.1.1</version>
 	<name>Google App Engine Profiler for Java</name>
 	<description>A mini profiler for the Google App Engine Java runtime (inspired by the Python gae_mini_profiler at https://github.com/kamens/gae_mini_profiler and the MVC Mini Profiler at http://code.google.com/p/mvc-mini-profiler/)</description>
 	<url>https://github.com/jriecken/gae-java-mini-profiler</url>
@@ -54,23 +54,23 @@
 		<dependency>
 			<groupId>com.google.appengine</groupId>
 			<artifactId>appengine-api-1.0-sdk</artifactId>
-			<version>1.7.6</version>
+			<version>1.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.appengine</groupId>
 			<artifactId>appengine-api-labs</artifactId>
-			<version>1.7.6</version>
+			<version>1.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.appengine</groupId>
 			<artifactId>appengine-testing</artifactId>
-			<version>1.7.6</version>
+			<version>1.8.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.google.appengine</groupId>
 			<artifactId>appengine-api-stubs</artifactId>
-			<version>1.7.6</version>
+			<version>1.8.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Updated gae dependancies to 1.8.0 and incremented version to 1.1.1. I'll be pushing the jar into the pipeline to get to maven central in a few minutes.

I'm surprised it's pulling in 13 commits. I meant to, and throught I did, branch directly from jrecken/gae-java-mini-profiler. Looking to see what I did wrong...
