### PR TITLE
MiniProfilerAppstats does not catch NumberFormatException

### DIFF
--- a/src/main/java/com/google/appengine/tools/appstats/MiniProfilerAppstats.java
+++ b/src/main/java/com/google/appengine/tools/appstats/MiniProfilerAppstats.java
@@ -49,7 +49,14 @@ public class MiniProfilerAppstats
   {
     Map<String, Object> appstatsMap = null;
     MemcacheWriter writer = new MemcacheWriter(null, MemcacheServiceFactory.getMemcacheService("__appstats__"));
-    StatsProtos.RequestStatProto appstats = writer.getFull(Long.parseLong(appstatsId));
+    StatsProtos.RequestStatProto appstats;
+    try
+    {
+      appstats = writer.getFull(Long.parseLong(appstatsId));
+    } catch (NumberFormatException e)
+    {
+      return appstatsMap;
+    }
     if (appstats != null)
     {
       appstatsMap = new HashMap<String, Object>();

--- a/src/test/java/com/google/appengine/tools/appstats/MiniProfilerAppstatsTest.java
+++ b/src/test/java/com/google/appengine/tools/appstats/MiniProfilerAppstatsTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2011 by Jim Riecken
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package  com.google.appengine.tools.appstats;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.appengine.tools.appstats.MiniProfilerAppstats;
+
+public class MiniProfilerAppstatsTest
+{
+    @Test
+    public void testGetAppstatsDataForInvalidId()
+    {
+        assertNull("Appstats data should be null", MiniProfilerAppstats.getAppstatsDataFor("testId",100));
+    }
+}


### PR DESCRIPTION
MiniProfilerAppstats.java calls `java.lang.long.parseLong` without first
checking whether the argument parses. This 
lead to an uncaught `NumberFormateException`: [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong%28java.lang.String,%20int%29). 

This pull request adds a check and a test for this issue.