### PR TITLE
Updated ReadMe and dependency library that had a vulnerable

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ Getting Started
 
 Clone the source from here and build it using [maven](http://maven.apache.org/).
 
+`mvn clean install`
+
+Requirements to Build
+ - Set JAVA_HOME environment variable
+ - Install gnupg (A guide can be found [here](http://blog.ghostinthemachines.com/2015/03/01/how-to-use-gpg-command-line/))
+ - If you get the following error "Inappropriate ioctl for device" try the following to fix the problem `export GPG_TTY=$(tty)`
+
 Then copy the `gae-mini-profiler-1.0.0.jar` file (and the two Jackson jars) to your `WEB-INF/lib` folder.
 
 <a name="configuration"></a>

--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,12 @@
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-core-asl</artifactId>
-			<version>1.8.5</version>
+			<version>1.9.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.8.5</version>
+			<version>1.9.13</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
With the below update the project is successfully building and all tests are passing.

The PR includes:

- pom.xml with updated dependency that does not contain any known vulnerabilities

- Updated ReadMe with a couple of build requirements based on my experience this afternoon

Since org.codehaus.jackson@1.8.5 has a known vulnerability this is the reason for the update.  The vulnerability is a hash collision attack.  This update will reduce the potential risk to a user and system.

Additional details on the vulnerability:
org.codehaus.jackson
https://www.sourceclear.com/registry/security/hash-collision-attacks/java/sid-3120